### PR TITLE
Upload a workflow that can compile and publish windows x64 release engine

### DIFF
--- a/.github/workflows/engine-windows-x64-release-build.yml
+++ b/.github/workflows/engine-windows-x64-release-build.yml
@@ -1,0 +1,69 @@
+name: Build Flutter Engine
+
+on: workflow_dispatch
+
+jobs:
+  build-engine:
+    runs-on: windows-latest
+
+    steps:
+      - name: Install Depot Tools
+        uses: newkdev/setup-depot-tools@v1.0.1
+
+      - name: Set environment variables
+        run: |
+          echo "DEPOT_TOOLS_WIN_TOOLCHAIN=0" >> $env:GITHUB_ENV
+          echo "GYP_MSVS_OVERRIDE_PATH=C:\Program Files\Microsoft Visual Studio\2022\Enterprise" >> $env:GITHUB_ENV
+          echo "WINDOWSSDKDIR=C:\Program Files (x86)\Windows Kits\10" >> $env:GITHUB_ENV
+
+      - name: Fetch Flutter
+        run: |
+          mkdir engine
+          cd engine
+          
+          # Set the .gclient file content
+          $gclientContent = @"
+          solutions = [
+              {
+                "custom_deps": {},
+                "deps_file": "DEPS",
+                "managed": False,
+                "name": "src/flutter",
+                "safesync_url": "",
+                "url": "https://github.com/rustdesk/engine.git",
+              },
+          ]
+          "@
+          # Writing .gclient Files
+          $gclientContent | Out-File -FilePath .gclient -Encoding utf8
+          
+          # Pull Flutter source code
+          gclient sync --with_branch_heads --with_tags
+          # fetch flutter
+          git -C src/flutter checkout flutter-3.24.4-fix-desktop-multi-window-plugin-crash
+          git -C src/flutter branch
+          git -C src/flutter status
+          gclient sync -D
+          
+          # Compiling the Flutter engine
+          cd src
+          python .\flutter\tools\gn --runtime-mode=release
+          ninja -C .\out\host_release
+          
+          # Check and compress files
+          $outputPath = "${{ github.workspace }}\windows-x64-release.zip"
+          $filesToCompress = Get-ChildItem -Path .\out\host_release\flutter_windows.dll*
+          if ($filesToCompress) {
+            Compress-Archive -Path $filesToCompress -DestinationPath $outputPath
+          } else {
+            Write-Error "Build output files not found!"
+          }
+
+      - name: Upload files to a GitHub release
+        uses: svenstaro/upload-release-action@2.9.0
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: windows-x64-release.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: "Flutter Engine Release"

--- a/.github/workflows/engine-windows-x64-release-build.yml
+++ b/.github/workflows/engine-windows-x64-release-build.yml
@@ -21,28 +21,17 @@ jobs:
           mkdir engine
           cd engine
           
-          # Set the .gclient file content
-          $gclientContent = @"
-          solutions = [
-              {
-                "custom_deps": {},
-                "deps_file": "DEPS",
-                "managed": False,
-                "name": "src/flutter",
-                "safesync_url": "",
-                "url": "https://github.com/rustdesk/engine.git",
-              },
-          ]
-          "@
-          # Writing .gclient Files
-          $gclientContent | Out-File -FilePath .gclient -Encoding utf8
-          
-          # Pull Flutter source code
-          gclient sync --with_branch_heads --with_tags
-          # fetch flutter
-          git -C src/flutter checkout flutter-3.24.4-fix-desktop-multi-window-plugin-crash
-          git -C src/flutter branch
+          fetch flutter
+          git -C src/flutter checkout db49896cf25ceabc44096d5f088d86414e05a7aa
+
+          $filePath = "src/flutter/shell/platform/windows/flutter_windows_engine.cc"
+          (Get-Content $filePath) -replace 'ClearCurrent', 'MakeCurrent' | Set-Content $filePath
+
+          $filePath = "src/flutter/fml/hex_codec.h"
+          (Get-Content $filePath | ForEach-Object { if ($_ -eq '#include <string_view>') {"#include <string>`n" + $_} else {$_}}) | Set-Content $filePath
+
           git -C src/flutter status
+          
           gclient sync -D
           
           # Compiling the Flutter engine
@@ -59,11 +48,12 @@ jobs:
             Write-Error "Build output files not found!"
           }
 
+      # The file will be uploaded to the release page of the repository, and the tag is the branch name of the currently executing workflow.
       - name: Upload files to a GitHub release
         uses: svenstaro/upload-release-action@2.9.0
         with:
           repo_token: ${{ secrets.GITHUB_TOKEN }}
-          file: windows-x64-release.zip
+          file: flutter-engine-windows-x64-release.zip
           tag: ${{ github.ref }}
           overwrite: true
           body: "Flutter Engine Release"


### PR DESCRIPTION
The compilation process follows the following tutorial:
https://github.com/flutter/engine/blob/main/docs/contributing/Setting-up-the-Engine-development-environment.md
https://github.com/flutter/engine/blob/main/docs/contributing/Compiling-the-engine.md

The gclient file configuration refers to the following official default configuration:
https://chromium.googlesource.com/chromium/tools/depot_tools.git/+/refs/heads/main/fetch_configs/flutter.py

How to use:
The workflow will release a zip archive. Copy the files in the archive to the flutter_windows_3.24.4-stable\flutter\bin\cache\artifacts\engine\windows-x64-release directory. Use the flutter build windows command to compile the application. You can verify that the replacement was successful by verifying the flutter_windows.dll file.